### PR TITLE
685750: Login with email instead of username

### DIFF
--- a/apps/badges/tests/test_views.py
+++ b/apps/badges/tests/test_views.py
@@ -13,7 +13,7 @@ class TestMonthStatsAjax(TestCase):
     fixtures = ['badge_instance']
 
     def test_basic(self):
-        self.client.login(username='testuser43', password='asdfasdf')
+        self.client.login(username='testuser43@asdf.asdf', password='asdfasdf')
         response = self.client.post(reverse('badges.ajax.stats'),
                                     {'month': 7, 'year': 2011})
 

--- a/apps/shared/forms.py
+++ b/apps/shared/forms.py
@@ -1,0 +1,13 @@
+from django import forms
+
+
+class FormBase(forms.Form):
+    """Handles common tasks among forms."""
+    placeholders = {}
+
+    def __init__(self, *args, **kwargs):
+        super(FormBase, self).__init__(*args, **kwargs)
+
+        # Add placeholders for fields
+        for field, placeholder in self.placeholders.items():
+            self.fields[field].widget.attrs['placeholder'] = placeholder

--- a/apps/users/backends.py
+++ b/apps/users/backends.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.models import User
+
+
+class EmailBackend(ModelBackend):
+    """Auth backend that uses an email address as the username."""
+    def authenticate(self, username=None, password=None):
+        try:
+            user = User.objects.get(email=username)
+        except User.DoesNotExist:
+            return None
+
+        if user.check_password(password):
+            return user

--- a/apps/users/templates/users/include/login_form.html
+++ b/apps/users/templates/users/include/login_form.html
@@ -1,20 +1,16 @@
 {% if login_form.errors %}
-  <p class="msg_warning">{{ _('Username or password incorrect.') }}</p>
+  {% for field, errors in login_form.errors.items() %}
+    {% for error in errors %}
+      <p class="msg_warning">{{ error }}</p>
+    {% endfor %}
+  {% endfor %}
 {% endif %}
 <form action="{{ url('users.login') }}" method="post" id="login-form">
   {{ csrf() }}
-  <input type="text"
-         name="{{ login_form.username.html_name }}"
-         placeholder="{{ _('Username') }}"
-         required/>
-  <input type="password"
-         name="{{ login_form.password.html_name }}"
-         placeholder="{{ _('Password') }}"
-         required/>
+  {{ login_form.username }}
+  {{ login_form.password }}
   <button type="submit">{{ _('Log in &raquo;') }}</button>
-  <input type="checkbox"
-         id="login-remember-me"
-         name="{{ login_form.remember_me.html_name }}" />
-  <label for="login-remember-me">{{ _('Remember me') }}</label>
+  {{ login_form.remember_me }}
+  <label for="id_remember_me">{{ _('Remember me') }}</label>
   <a href="{{ url('users.send_password_reset') }}">{{ _('Forgot your password?') }}</a>
 </form>

--- a/apps/users/tests/test_forms.py
+++ b/apps/users/tests/test_forms.py
@@ -109,12 +109,32 @@ class SetPasswordFormTests(TestCase):
     fixtures = ['registered_users']
 
     def _form(self, pw, pw2):
-        return forms.SetPasswordForm({'new_password1': pw,
-                                      'new_password2': pw2})
+        return forms.SetPasswordForm(None, data={'new_password1': pw,
+                                                 'new_password2': pw2})
 
-    def passwords_must_match(self):
+    def test_passwords_must_match(self):
         form = self._form('asdf1234', 'asdf1234')
         ok_(form.is_valid())
 
         form = self._form('asdf1234', 'qwer5678')
+        ok_(not form.is_valid())
+
+
+class LoginFormTests(TestCase):
+    fixtures = ['registered_users']
+
+    def _form(self, email, password):
+        return forms.LoginForm(data={'username': email, 'password': password})
+
+    def test_basic(self):
+        form = self._form('mkelly@mozilla.com', 'asdfasdf')
+        ok_(form.is_valid())
+        eq_(form.get_user().username, 'mkelly')
+
+    def test_wrong_username(self):
+        form = self._form('honey@badger.net', 'dontcare')
+        ok_(not form.is_valid())
+
+    def test_wrong_password(self):
+        form = self._form('mkelly@mozilla.com', 'incorrect')
         ok_(not form.is_valid())

--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -65,7 +65,7 @@ class LoginTests(TestCase):
 
     def test_basic_login(self):
         """Test that a basic login works."""
-        parameters = {'username': 'mkelly', 'password': 'asdfasdf'}
+        parameters = {'username': 'mkelly@mozilla.com', 'password': 'asdfasdf'}
         response = self.client.post(reverse('users.login'), parameters)
 
         ok_(response.cookies[settings.SESSION_COOKIE_NAME])
@@ -76,7 +76,7 @@ class LoginTests(TestCase):
         Test that logging in with "Remember me" checked sets the
         session expiration.
         """
-        parameters = {'username': 'mkelly', 'password': 'asdfasdf',
+        parameters = {'username': 'mkelly@mozilla.com', 'password': 'asdfasdf',
                       'remember_me': True}
         response = self.client.post(reverse('users.login'), parameters)
 
@@ -88,7 +88,7 @@ class EditProfileTests(TestCase):
     fixtures = ['registered_users']
 
     def setUp(self):
-        self.client.login(username='mkelly', password='asdfasdf')
+        self.client.login(username='mkelly@mozilla.com', password='asdfasdf')
 
     def _params(self, **kwargs):
         """Default arguments for profile edit form."""

--- a/settings.py
+++ b/settings.py
@@ -15,7 +15,10 @@ AFFILIATES_LANGUAGES = ['en-US']
 # Email settings
 DEFAULT_FROM_EMAIL = 'notifications@affiliates.mozilla.com'
 
-# User account profiles
+# User accounts
+AUTHENTICATION_BACKENDS = (
+    'users.backends.EmailBackend',
+)
 AUTH_PROFILE_MODULE = 'users.UserProfile'
 
 # Login settings


### PR DESCRIPTION
Changes the login form and authentication backend to use emails instead of usernames for login.
