### PR TITLE
Fix hover javascript.

### DIFF
--- a/apps/users/templates/users/include/edit_profile_form.html
+++ b/apps/users/templates/users/include/edit_profile_form.html
@@ -29,7 +29,7 @@
   </div>
   <div class="section">
     <div>
-      {% call macros.fields_title(_('ADDRESS')) %}
+      {% call macros.fields_title(_('ADDRESS'), 'address-help') %}
         {% trans %}
           Why should I provide my mailing address?
           <br/><br/>

--- a/apps/users/templates/users/include/macros.html
+++ b/apps/users/templates/users/include/macros.html
@@ -1,10 +1,10 @@
-{% macro fields_title(title) -%}
-  {% set help = caller is defined %}
+{% macro fields_title(title, target='') -%}
+  {% set help = caller is defined and target != '' %}
   <h4 {{ help|ifeq(true, 'class="has_bulb"') }}>{{ title }}</h4>
   {% if help %}
     <div class="help_bulb_wrapper">
-      <a href="#" class="help_bulb show_tooltip"></a>
-      <div class="tool-tip left-arrow">
+      <a href="#" class="help_bulb show_tooltip" target="{{ target }}"></a>
+      <div id="{{ target }}" class="tool-tip left-arrow">
         <span></span>
         <p>{{ caller() }}</p>
       </div>

--- a/media/js/affiliates.js
+++ b/media/js/affiliates.js
@@ -43,12 +43,10 @@ var HomePage = {
             });
             $(".show_tooltip").hover(
                 function(e){
-                    HomePage.toggleToolTip($(this).siblings('.tool-tip'),
-                                           e.type);
+                    HomePage.toggleToolTip($(this).attr('target'), e.type);
                 },
                 function(e){
-                    HomePage.toggleToolTip($(this).siblings('.tool-tip'),
-                                           e.type);
+                    HomePage.toggleToolTip($(this).attr('target'), e.type);
                 });
         }
         if($.browser.msie) {
@@ -58,7 +56,9 @@ var HomePage = {
             $(".js_uniform").uniform();
         }
     },
-    toggleToolTip: function(tooltip, e){
+    toggleToolTip: function(target, e){
+        var tooltip = $('#' + target);
+
         if (e == "mouseenter") {
             tooltip.show();
         } else {


### PR DESCRIPTION
Reverted a previous change that tried to find a sibling tooltip element and
show it. Instead a target is defined on the tooltip link, which defines what
element is shown on hover.
