### PR TITLE
Mock out BannerImage size method for tests.

### DIFF
--- a/apps/banners/tests/__init__.py
+++ b/apps/banners/tests/__init__.py
@@ -1,0 +1,8 @@
+# Sizes for banners/fixtures/banners.json
+sizes = ['120x240', '120x240', '120x240', '300x250', '300x250']
+
+
+@property
+def mock_size(self):
+    """Mock method to prevent tests from trying to open nonexistent images."""
+    return '%s pixels' % sizes[self.pk - 1]

--- a/apps/banners/tests/test_models.py
+++ b/apps/banners/tests/test_models.py
@@ -4,9 +4,11 @@ from mock import patch
 from nose.tools import eq_
 from test_utils import TestCase
 
-from banners.models import Banner
+from banners.models import Banner, BannerImage
+from banners.tests import mock_size
 
 
+@patch.object(BannerImage, 'size', mock_size)
 @patch.object(settings, 'SITE_ID', 1)
 class BannerImageTests(TestCase):
     fixtures = ['banners', 'sites']

--- a/apps/banners/tests/test_views.py
+++ b/apps/banners/tests/test_views.py
@@ -8,9 +8,11 @@ from nose.tools import eq_, ok_
 from test_utils import TestCase
 
 from badges.tests import LocalizingClient
-from banners.models import Banner, BannerInstance
+from banners.models import Banner, BannerImage, BannerInstance
+from banners.tests import mock_size
 
 
+@patch.object(BannerImage, 'size', mock_size)
 class CustomizeViewTests(TestCase):
     client_class = LocalizingClient
     fixtures = ['banners']


### PR DESCRIPTION
BannerImage.size reads the filesystem to determine image size, which breaks tests
where the image files don't exist. Mocking this method out avoids having to read
the filesystem to get a size.

fix bug 690882
