### PR TITLE
Default to en-US with babel formatting on error.

### DIFF
--- a/apps/badges/helpers.py
+++ b/apps/badges/helpers.py
@@ -1,11 +1,12 @@
 from django.utils.translation import get_language
 
 import bleach
-from babel.core import Locale
 from babel.dates import format_date
 from babel.numbers import format_number
 from jingo import register
 from jinja2 import Markup
+
+from shared.utils import current_locale
 
 
 @register.filter
@@ -28,7 +29,7 @@ def babel_date(date, format='long'):
     Format a date properly for the current locale. Format can be one of
     'short', 'medium', 'long', or 'full'.
     """
-    locale = Locale.parse(get_language(), sep='-')
+    locale = current_locale()
     return format_date(date, format, locale)
 
 
@@ -45,5 +46,5 @@ def linkify(str, *args, **kwargs):
 @register.filter
 def babel_number(number):
     """Format a number properly for the current locale."""
-    locale = Locale.parse(get_language(), sep='-')
+    locale = current_locale()
     return format_number(number, locale)

--- a/apps/badges/views.py
+++ b/apps/badges/views.py
@@ -8,7 +8,6 @@ from django.utils.http import urlquote_plus
 from django.utils.translation import get_language
 
 import jingo
-from babel.core import Locale
 from babel.dates import get_month_names
 from babel.numbers import format_number
 from session_csrf import anonymous_csrf
@@ -18,7 +17,7 @@ from badges.models import (Badge, BadgeInstance, Category, ClickStats,
                            Leaderboard, Subcategory)
 from news.models import NewsItem
 from shared.decorators import login_required
-from shared.utils import absolutify, redirect
+from shared.utils import absolutify, current_locale, redirect
 from users.forms import RegisterForm, LoginForm
 
 
@@ -82,7 +81,7 @@ def dashboard(request, template, context=None):
     if context is None:
         context = {}
 
-    locale = Locale.parse(get_language(), sep='-')
+    locale = current_locale()
 
     # Set context variables needed by all dashboard pages
     context['newsitem'] = NewsItem.objects.current()
@@ -126,7 +125,7 @@ def month_stats_ajax(request):
     site_avg = ClickStats.objects.average_for_period(month=request.POST['month'],
                                                      year=request.POST['year'])
 
-    locale = Locale.parse(get_language(), sep='-')
+    locale = current_locale()
     results = {'user_total': format_number(user_total, locale=locale),
                'site_avg': format_number(site_avg, locale=locale)}
     return HttpResponse(json.dumps(results), mimetype='application/json')

--- a/apps/shared/tests/test__utils.py
+++ b/apps/shared/tests/test__utils.py
@@ -1,10 +1,12 @@
 from django.conf import settings
 
+from babel.core import Locale
 from mock import patch
 from nose.tools import eq_
 from test_utils import TestCase
+from tower import activate
 
-from shared.utils import absolutify, redirect
+from shared.utils import absolutify, current_locale, redirect
 
 
 @patch.object(settings, 'SITE_ID', 1)
@@ -41,3 +43,18 @@ class TestRedirect(TestCase):
         response = redirect('mock_view', permanent=True)
         eq_(response.status_code, 301)
         eq_(response['Location'], '/en-US/mock_view')
+
+
+class TestCurrentLocale(TestCase):
+    def test_basic(self):
+        """Test that the currently locale is correctly returned."""
+        activate('fr')
+        eq_(Locale('fr'), current_locale())
+
+    def test_unknown(self):
+        """
+        Test that when the current locale is not supported by Babel, it
+        defaults to en-US.
+        """
+        activate('fy')
+        eq_(Locale('en', 'US'), current_locale())

--- a/apps/shared/utils.py
+++ b/apps/shared/utils.py
@@ -5,6 +5,7 @@ from django.contrib.sites.models import Site
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.utils.translation import get_language
 
+from babel.core import Locale, UnknownLocaleError
 from funfactory.urlresolvers import reverse
 from product_details import product_details
 
@@ -52,3 +53,15 @@ def redirect(to, permanent=False, **kwargs):
         redirect_class = HttpResponseRedirect
 
     return redirect_class(reverse(to, **kwargs))
+
+
+def current_locale():
+    """
+    Return the current Locale object (from Babel). Defaults to en-US if locale
+    does not exist.
+    """
+    try:
+        return Locale.parse(get_language(), sep='-')
+    except UnknownLocaleError:
+        # Default to en-US
+        return Locale('en', 'US')


### PR DESCRIPTION
Whenever a locale is not supported by Babel, we fall back to using en-US as
the locale for formatting.

fix bug 692314
