### PR TITLE
Use Celery to increment clicks.

### DIFF
--- a/apps/banners/tasks.py
+++ b/apps/banners/tasks.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from django.db import IntegrityError, models
+
+from celery.decorators import task
+
+from banners.models import BannerInstance
+
+
+@task
+def add_click(user_id, banner_id, banner_img_id):
+    """Increment the click count for a banner."""
+    now = datetime.now()
+
+    try:
+        instance, created = BannerInstance.objects.get_or_create(
+            user_id=user_id,
+            badge_id=banner_id,
+            image_id=banner_img_id
+        )
+    except IntegrityError:
+        # One of the IDs is wrong, causing a foreign key constraint to fail.
+        # This isn't an app error, so we ignore this.
+        return
+
+    stats, created = instance.clickstats_set.get_or_create(month=now.month,
+                                                           year=now.year)
+    stats.clicks = models.F('clicks') + 1
+    stats.save()

--- a/apps/banners/tests/test_views.py
+++ b/apps/banners/tests/test_views.py
@@ -37,8 +37,7 @@ class LinkViewTests(TestCase):
     BANNER_ID = 1
     USER_ID = 1
     BANNER_IMG_ID = 1
-
-    BAD_BANNER_IMG_ID = 666
+    BAD_BANNER_ID = 666
 
     def test_basic(self):
         kwargs = {'user_id': self.USER_ID,
@@ -60,8 +59,8 @@ class LinkViewTests(TestCase):
     @patch.object(settings, 'DEFAULT_AFFILIATE_LINK', 'http://testlink.com')
     def test_redirect_default_on_error(self):
         kwargs = {'user_id': self.USER_ID,
-                  'banner_id': self.BANNER_ID,
-                  'banner_img_id': self.BAD_BANNER_IMG_ID}
+                  'banner_id': self.BAD_BANNER_ID,
+                  'banner_img_id': self.BANNER_IMG_ID}
         url = reverse('banners.link', kwargs=kwargs)
         response = self.client.get(url)
 

--- a/apps/banners/views.py
+++ b/apps/banners/views.py
@@ -1,17 +1,15 @@
 import json
 
 from django.conf import settings
-from django.core.cache import cache
-from django.db import IntegrityError
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.translation import get_language
 from django.views.decorators.cache import never_cache
 
-from badges.utils import handle_affiliate_link
 from badges.views import dashboard
+from banners import tasks
 from banners.urls import AFFILIATE_LINK
-from banners.models import Banner, BannerImage, BannerInstance, BANNER_TEMPLATE
+from banners.models import Banner, BANNER_TEMPLATE
 from shared.decorators import login_required
 
 
@@ -41,25 +39,13 @@ def customize(request, banner_pk=None):
                          'json_size_colors': json_size_colors})
 
 
-# TODO: Remove need for banner_id in link
 @never_cache
 def link(request, user_id, banner_id, banner_img_id):
     try:
-        banner_img = (BannerImage.objects.select_related('Banner')
-                      .get(pk=banner_img_id))
-    except BannerImage.DoesNotExist:
+        banner = Banner.objects.get(pk=banner_id)
+    except Banner.DoesNotExist:
         return HttpResponseRedirect(settings.DEFAULT_AFFILIATE_LINK)
 
-    key = CACHE_LINK_INSTANCE % (user_id, banner_img_id)
-    instance = cache.get(key)
-    if instance is None:
-        try:
-            instance, created = (BannerInstance.objects.select_related('badge')
-                                 .get_or_create(user_id=user_id,
-                                                badge=banner_img.banner,
-                                                image=banner_img))
-            cache.set(key, instance)
-        except IntegrityError:
-            return HttpResponseRedirect(settings.DEFAULT_AFFILIATE_LINK)
+    tasks.add_click.delay(user_id, banner_id, banner_img_id)
 
-    return handle_affiliate_link(instance)
+    return HttpResponseRedirect(banner.href)


### PR DESCRIPTION
Affiliate links now use just 1 query to redirect users, and push
the link-count-increment logic off to a Celery task.
