### PR TITLE
Admin interface improvements

### DIFF
--- a/apps/badges/admin.py
+++ b/apps/badges/admin.py
@@ -5,10 +5,10 @@ from badges.models import Category, Subcategory
 
 
 class CategoryAdmin(admin.ModelAdmin):
-    pass
+    change_list_template = 'smuggler/change_list.html'
 site.register(Category, CategoryAdmin)
 
 
 class SubcategoryAdmin(admin.ModelAdmin):
-    pass
+    change_list_template = 'smuggler/change_list.html'
 site.register(Subcategory, SubcategoryAdmin)

--- a/apps/banners/__init__.py
+++ b/apps/banners/__init__.py
@@ -1,0 +1,6 @@
+from tower import ugettext as _
+
+
+COLORS = ['Blue', 'Green', 'Red', 'Orange', 'Yellow', 'White', 'Black']
+LOCALIZED_COLORS = [_(color) for color in COLORS]
+COLOR_CHOICES = zip(COLORS, LOCALIZED_COLORS)

--- a/apps/banners/admin.py
+++ b/apps/banners/admin.py
@@ -6,8 +6,13 @@ from funfactory.urlresolvers import reverse
 from banners.models import Banner, BannerImage, BannerInstance
 
 
+class BannerImageInline(admin.TabularInline):
+    model = BannerImage
+
+
 class BannerAdmin(admin.ModelAdmin):
-    pass
+    change_list_template = 'smuggler/change_list.html'
+    inlines = [BannerImageInline]
 site.register(Banner, BannerAdmin)
 
 

--- a/apps/banners/models.py
+++ b/apps/banners/models.py
@@ -8,6 +8,7 @@ from funfactory.manage import path
 from tower import ugettext_lazy as _lazy
 
 from badges.models import Badge, BadgeInstance, LocaleField, ModelBase
+from banners import COLOR_CHOICES
 from shared.utils import absolutify
 
 # L10n: Width and height are the width and height of an image.
@@ -68,9 +69,10 @@ class BannerImageManager(CachingManager):
 class BannerImage(CachingMixin, ModelBase):
     """Image that a user can choose for their specific banner."""
     banner = models.ForeignKey(Banner)
-    color = models.CharField(max_length=20, verbose_name=_lazy(u'image color'))
+    color = models.CharField(max_length=20, choices=COLOR_CHOICES,
+                             verbose_name=u'image color')
     image = models.ImageField(upload_to=settings.BANNER_IMAGE_PATH,
-                              verbose_name=_lazy(u'image file'),
+                              verbose_name=u'image file',
                               max_length=settings.MAX_FILEPATH_LENGTH)
     locale = LocaleField()
 


### PR DESCRIPTION
- BannerImages should be able to be created directly from a Banner's edit or create page.
- Banners, Categories, Subcategories, and BannerImages should all have 'Dump data' and 'Load data' options.
- BannerImage colors should be selectable from a dropdown of available colors.
