### PR TITLE
Fix badge locale migration

### DIFF
--- a/migrations/20-add-existing-badges-to-all-locales.py
+++ b/migrations/20-add-existing-badges-to-all-locales.py
@@ -1,14 +1,22 @@
 """Add all existing locales as enabled for all badges."""
-from badges.models import Badge, BadgeLocale
-from shared.models import LANGUAGE_CHOICES
+try:
+    from badges.models import Badge, BadgeLocale
+    from shared.models import LANGUAGE_CHOICES
+
+    abort = False
+except ImportError:
+    # BadgeLocale was removed by a subsequent commit, and causes an ImportError.
+    # We can safely skip this in that case.
+    abort = True
 
 
 def run():
-    locales = [lang[0] for lang in LANGUAGE_CHOICES]
+    if not abort:
+        locales = [lang[0] for lang in LANGUAGE_CHOICES]
 
-    for badge in Badge.objects.all():
-        badge_locales = [BadgeLocale(badge=badge, locale=locale)
-                         for locale in locales]
-        badge.badgelocale_set.all().delete()
-        badge.badgelocale_set = badge_locales
-        badge.save()
+        for badge in Badge.objects.all():
+            badge_locales = [BadgeLocale(badge=badge, locale=locale)
+                             for locale in locales]
+            badge.badgelocale_set.all().delete()
+            badge.badgelocale_set = badge_locales
+            badge.save()


### PR DESCRIPTION
Because BadgeLocale was removed, this migration fails on new installs. This update allows the migration to run and fail silently if the class is not found.
