### PR TITLE
Adding missing string within transblock on 404 page

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -28,7 +28,7 @@
 
 {% block content %}
   <ul>
-    <li>If you typed in the address, check your spelling. Could just be a typo.</li>
+    <li>{% trans %}If you typed in the address, check your spelling. Could just be a typo.{% endtrans %}</li>
     <li>
       {% trans email='affiliates@mozilla.com' %}
         If you followed a link, it’s probably broken. Please


### PR DESCRIPTION
Adding missing string within transblock on 404 page
