### PR TITLE
Add BrowserID to more locales.

### DIFF
--- a/apps/shared/views.py
+++ b/apps/shared/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import render
 from django.utils.http import urlquote_plus
 from django.utils.translation import get_language
@@ -31,7 +32,7 @@ def home(request, register_form=None, login_form=None):
         return redirect('badges.new.step1')
 
     # en-US users see the BrowserID view instead
-    if get_language() == 'en-us':
+    if get_language() in settings.BROWSERID_LOCALES:
         return browserid_home(request)
 
     if register_form is None:

--- a/settings/base.py
+++ b/settings/base.py
@@ -40,6 +40,10 @@ PASSWORD_RESET_TIMEOUT_DAYS = 2
 BROWSERID_VERIFICATION_URL = 'https://browserid.org/verify'
 BROWSERID_DISABLE_CERT_CHECK = False
 BROWSERID_CREATE_USER = False
+BROWSERID_LOCALES = [lang.lower() for lang in (
+    'cs', 'de', 'en-US', 'es', 'fr', 'fy-NL', 'hr', 'nl', 'pl', 'pt-BR', 'sk',
+    'sl', 'sq', 'sr', 'zh-TW'
+    )]
 
 # Login settings
 LOGIN_VIEW_NAME = 'home'


### PR DESCRIPTION
Adds BrowserID to every locale except sr-Latn, matching the currently released locales for BrowserID.
