### PR TITLE
Non release locale banners

### DIFF
--- a/apps/badges/admin.py
+++ b/apps/badges/admin.py
@@ -1,15 +1,17 @@
 from django.contrib import admin
 
 from funfactory.admin import site
+
 from badges.models import BadgePreview, Category, Subcategory
+from shared.admin import BaseModelAdmin
 
 
-class CategoryAdmin(admin.ModelAdmin):
+class CategoryAdmin(BaseModelAdmin):
     change_list_template = 'smuggler/change_list.html'
 site.register(Category, CategoryAdmin)
 
 
-class SubcategoryAdmin(admin.ModelAdmin):
+class SubcategoryAdmin(BaseModelAdmin):
     change_list_template = 'smuggler/change_list.html'
 site.register(Subcategory, SubcategoryAdmin)
 

--- a/apps/banners/admin.py
+++ b/apps/banners/admin.py
@@ -6,6 +6,7 @@ from funfactory.urlresolvers import reverse
 from badges.admin import BadgePreviewInline
 from badges.models import ClickStats
 from banners.models import Banner, BannerImage, BannerInstance
+from shared.admin import BaseModelAdmin
 
 
 class BannerImageInline(admin.TabularInline):
@@ -13,10 +14,10 @@ class BannerImageInline(admin.TabularInline):
     extra = 0
 
 
-class BannerAdmin(admin.ModelAdmin):
-    list_display = ('__unicode__', 'clicks')
+class BannerAdmin(BaseModelAdmin):
     change_list_template = 'admin/banner_change_list.html'
     inlines = [BadgePreviewInline, BannerImageInline]
+    list_display = ('__unicode__', 'clicks')
 
     def changelist_view(self, request, extra_context={}):
         extra_context.update(total=ClickStats.objects.total())
@@ -26,7 +27,7 @@ class BannerAdmin(admin.ModelAdmin):
 site.register(Banner, BannerAdmin)
 
 
-class BannerImageAdmin(admin.ModelAdmin):
+class BannerImageAdmin(BaseModelAdmin):
     change_list_template = 'smuggler/change_list.html'
     list_display = ('banner', 'color', 'size', 'locale', 'image')
     list_editable = ('color', 'image')
@@ -34,10 +35,10 @@ class BannerImageAdmin(admin.ModelAdmin):
 site.register(BannerImage, BannerImageAdmin)
 
 
-class BannerInstanceAdmin(admin.ModelAdmin):
-    readonly_fields = ('clicks', 'created')
+class BannerInstanceAdmin(BaseModelAdmin):
     list_display = ('badge', 'user_display_name', 'image', 'clicks')
     list_filter = ('badge', 'image')
+    readonly_fields = ('clicks', 'created')
     search_fields = ('badge', 'user')
 
     def user_display_name(self, instance):

--- a/apps/news/admin.py
+++ b/apps/news/admin.py
@@ -1,10 +1,10 @@
-from django.contrib import admin
-
 from funfactory.admin import site
+
 from news.models import NewsItem
+from shared.admin import BaseModelAdmin
 
 
-class NewsItemAdmin(admin.ModelAdmin):
+class NewsItemAdmin(BaseModelAdmin):
     list_display = ('title', 'enabled', 'created', 'modified')
     list_editable = ('enabled',)
 site.register(NewsItem, NewsItemAdmin)

--- a/apps/shared/admin.py
+++ b/apps/shared/admin.py
@@ -1,0 +1,8 @@
+from django.contrib.admin import ModelAdmin
+
+from shared.forms import AdminModelForm
+
+
+class BaseModelAdmin(ModelAdmin):
+    """Base class for ModelAdmins used across the site."""
+    form = AdminModelForm

--- a/apps/shared/forms.py
+++ b/apps/shared/forms.py
@@ -1,5 +1,15 @@
 from django import forms
 
+from product_details import product_details
+
+from shared.models import LocaleField
+
+
+ENGLISH_LANGUAGE_CHOICES = sorted(
+    [(key.lower(), u'{0} ({1})'.format(key, value['English']))
+     for key, value in product_details.languages.items()]
+    )
+
 
 class FormBase(forms.Form):
     """Handles common tasks among forms."""
@@ -12,3 +22,17 @@ class FormBase(forms.Form):
         for field_name, placeholder in self.placeholders.items():
             field = self.fields[field_name]
             field.widget.attrs['placeholder'] = placeholder
+
+
+class AdminModelForm(forms.ModelForm):
+    """Special form class that handles admin-interface-specific changes."""
+    def __init__(self, *args, **kwargs):
+        super(AdminModelForm, self).__init__(*args, **kwargs)
+
+        # If there are any LocaleFields in this form, we want to display the
+        # locale names in English in the admin interface.
+        model_fields = self.Meta.model._meta.fields
+        for field in model_fields:
+            if isinstance(field, LocaleField):
+                # Change choices for form field to English choices.
+                self.fields[field.name].choices = ENGLISH_LANGUAGE_CHOICES

--- a/apps/shared/models.py
+++ b/apps/shared/models.py
@@ -1,12 +1,15 @@
 from django.conf import settings
 from django.db import models
 
+from product_details import product_details
 from tower import ugettext as _
 
 from shared.utils import unicode_choice_sorted
 
 
-LANGUAGE_CHOICES = unicode_choice_sorted(settings.LANGUAGES.items())
+LANGUAGE_CHOICES = unicode_choice_sorted([(key.lower(), value['native'])
+                                          for key, value in
+                                          product_details.languages.items()])
 
 
 class ModelBase(models.Model):

--- a/apps/shared/tests/test_forms.py
+++ b/apps/shared/tests/test_forms.py
@@ -1,0 +1,29 @@
+from django.db import models
+
+from nose.tools import eq_
+
+from shared.forms import AdminModelForm
+from shared.models import LocaleField
+from shared.tests import TestCase
+
+
+class AdminModelFormTests(TestCase):
+    def test_localefield_choices(self):
+        """
+        Test that any LocaleFields in the form use English labels for the
+        field choices.
+        """
+        class TestModel(models.Model):
+            locale = LocaleField()
+
+        class TestForm(AdminModelForm):
+            class Meta:
+                model = TestModel
+
+        f = TestForm()
+        labels = dict(f.fields['locale'].choices)
+
+        # Since product_details rarely changes, assuming what names it will
+        # provide for each locale is safe enough for this test.
+        eq_(labels['it'], 'it (Italian)')
+        eq_(labels['ko'], 'ko (Korean)')

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from funfactory.admin import site
 
 from users.models import UserProfile
+from shared.admin import BaseModelAdmin
 
 
 class UserProfileInline(admin.StackedInline):
@@ -17,7 +18,7 @@ class UserProfileInline(admin.StackedInline):
     )
 
 
-class UserAdmin(admin.ModelAdmin):
+class UserAdmin(BaseModelAdmin):
     list_display = ('user_displayname', 'email', 'is_active', 'last_login',
                     'date_joined')
     list_filter = ('is_active',)


### PR DESCRIPTION
Changes LocaleField to allow any locale defined in product_details
to be used, making it possible to add BannerImages from locales
that the site has yet to be translated in.

In addition, this uses a custom ModelForm on every ModelAdmin object
across the site to change the labels for LocaleFields in the admin
interface to use English labels instead of localized labels.

fix bug 713041
