### PR TITLE
Fixes an issue with unsupported locales.

### DIFF
--- a/apps/banners/models.py
+++ b/apps/banners/models.py
@@ -15,7 +15,8 @@ from badges.models import Badge, BadgeInstance
 from banners import COLOR_CHOICES
 from shared.models import LocaleField, ModelBase
 from shared.storage import OverwritingStorage
-from shared.utils import absolutify, ugettext_locale as _locale
+from shared.utils import (absolutify, product_languages_lower,
+                          ugettext_locale as _locale)
 
 
 # L10n: Width and height are the width and height of an image.
@@ -58,7 +59,7 @@ class BannerImageManager(CachingManager):
             'area': img.image.width * img.image.height,
             'color': img.color,
             'url': img.image.url,
-            'language': settings.LANGUAGES[img.locale]
+            'language': product_languages_lower[img.locale]['native']
             } for img in self.filter(**kwargs)]
 
 

--- a/apps/shared/utils.py
+++ b/apps/shared/utils.py
@@ -1,4 +1,4 @@
-import locale
+from locale import strcoll as locale_strcoll
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -9,6 +9,14 @@ import tower
 from babel.core import Locale, UnknownLocaleError
 from funfactory.urlresolvers import reverse
 from product_details import product_details
+
+
+product_languages_lower = dict((locale.lower(), data) for locale, data in
+                               product_details.languages.items())
+"""
+Stores info about languages from product_details using lower-cased locale names
+(because the DB stores locales in that format).
+"""
 
 
 def absolutify(url, https=False, cdn=False):
@@ -31,7 +39,7 @@ def unicode_choice_sorted(choices):
     """
     Sorts a list of 2-tuples by the second value, using a unicode-safe sort.
     """
-    return sorted(choices, cmp=lambda x, y: locale.strcoll(x[1], y[1]))
+    return sorted(choices, cmp=lambda x, y: locale_strcoll(x[1], y[1]))
 
 
 def country_choices():


### PR DESCRIPTION
Adds a product_language_lower dict that allows one to retrieve
the English and native names of a language using the lower-case
version of a locale code (as our database does) in order to
fix an issue in the customize view where it couldn't find
the name for locales that the site isn't fully localized
in.

Also changes the import name for the unfortunately-named
locale module.

fix bug 772882
