### PR TITLE
Use English locale names in the admin interface.

### DIFF
--- a/apps/shared/forms.py
+++ b/apps/shared/forms.py
@@ -1,15 +1,5 @@
 from django import forms
 
-from product_details import product_details
-
-from shared.models import LocaleField
-
-
-ENGLISH_LANGUAGE_CHOICES = sorted(
-    [(key.lower(), u'{0} ({1})'.format(key, value['English']))
-     for key, value in product_details.languages.items()]
-    )
-
 
 class FormBase(forms.Form):
     """Handles common tasks among forms."""
@@ -26,13 +16,4 @@ class FormBase(forms.Form):
 
 class AdminModelForm(forms.ModelForm):
     """Special form class that handles admin-interface-specific changes."""
-    def __init__(self, *args, **kwargs):
-        super(AdminModelForm, self).__init__(*args, **kwargs)
-
-        # If there are any LocaleFields in this form, we want to display the
-        # locale names in English in the admin interface.
-        model_fields = self.Meta.model._meta.fields
-        for field in model_fields:
-            if isinstance(field, LocaleField):
-                # Change choices for form field to English choices.
-                self.fields[field.name].choices = ENGLISH_LANGUAGE_CHOICES
+    pass  # Retained for possible future use.

--- a/apps/shared/models.py
+++ b/apps/shared/models.py
@@ -4,12 +4,11 @@ from django.db import models
 from product_details import product_details
 from tower import ugettext as _
 
-from shared.utils import unicode_choice_sorted
 
-
-LANGUAGE_CHOICES = unicode_choice_sorted([(key.lower(), value['native'])
-                                          for key, value in
-                                          product_details.languages.items()])
+ENGLISH_LANGUAGE_CHOICES = sorted(
+    [(key.lower(), u'{0} ({1})'.format(key, value['English']))
+     for key, value in product_details.languages.items()]
+)
 
 
 class ModelBase(models.Model):
@@ -58,7 +57,7 @@ class LocaleField(models.CharField):
                    'defaults.')
 
     def __init__(self, max_length=32, default=settings.LANGUAGE_CODE,
-                 choices=LANGUAGE_CHOICES, *args, **kwargs):
+                 choices=ENGLISH_LANGUAGE_CHOICES, *args, **kwargs):
         return super(LocaleField, self).__init__(
             max_length=max_length, default=default, choices=choices,
             *args, **kwargs)


### PR DESCRIPTION
Since the only area outside of the admin interface that uses
locale names explicitly pulls the native names, we can just
set the default string representation of locales to the locale
code and English name to make it easier for Chelsea to 
figure out which language is which. :D

fix bug 765347
