### PR TITLE
Fix extra click

### DIFF
--- a/apps/facebook/tests/__init__.py
+++ b/apps/facebook/tests/__init__.py
@@ -15,6 +15,10 @@ from shared.tokens import TokenGenerator
 from users.tests import UserFactory
 
 
+FACEBOOK_USER_AGENT = ('facebookexternalhit/1.1 (+http://www.facebook.com/'
+                       'externalhit_uatext.php)')
+
+
 def path(*a):
     return os.path.join(dirname(abspath(__file__)), *a)
 

--- a/apps/facebook/tests/test__utils.py
+++ b/apps/facebook/tests/test__utils.py
@@ -9,9 +9,9 @@ from django.test.client import RequestFactory
 from mock import patch
 from nose.tools import eq_
 
-from facebook.tests import create_payload
+from facebook.tests import FACEBOOK_USER_AGENT, create_payload
 from facebook.utils import (activate_locale, decode_signed_request,
-                            modified_url_b64decode)
+                            is_facebook_bot, modified_url_b64decode)
 from shared.tests import TestCase
 
 
@@ -122,3 +122,16 @@ class ActivateLocaleTests(TestCase):
         request = self.factory.get('/')
         activate_locale(request, 'en-us')
         eq_(getattr(request, 'locale', None), None)
+
+
+class IsFacebookBotTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_is_bot(self):
+        request = self.factory.get('/', HTTP_USER_AGENT=FACEBOOK_USER_AGENT)
+        eq_(is_facebook_bot(request), True)
+
+    def test_is_not_a_bot(self):
+        request = self.factory.get('/', HTTP_USER_AGENT='not.facebook')
+        eq_(is_facebook_bot(request), False)

--- a/apps/facebook/utils.py
+++ b/apps/facebook/utils.py
@@ -70,6 +70,14 @@ def is_logged_in(request):
             isinstance(request.user, FacebookUser))
 
 
+def is_facebook_bot(request):
+    """Check the request's User-Agent against the Facebook bot's User-Agent."""
+    if 'HTTP_USER_AGENT' in request.META:
+        return request.META['HTTP_USER_AGENT'].startswith('facebookexternalhit')
+    else:
+        return False
+
+
 def current_hour():
     """Return a datetime representing the current hour."""
     now = datetime.now()

--- a/apps/facebook/views.py
+++ b/apps/facebook/views.py
@@ -20,7 +20,8 @@ from facebook.forms import (FacebookAccountLinkForm, FacebookBannerInstanceForm,
 from facebook.tasks import add_click, generate_banner_instance_image
 from facebook.models import (FacebookAccountLink, FacebookBannerInstance,
                              FacebookClickStats, FacebookUser)
-from facebook.utils import activate_locale, decode_signed_request, is_logged_in
+from facebook.utils import (activate_locale, decode_signed_request,
+                            is_facebook_bot, is_logged_in)
 from shared.http import JSONResponse
 from shared.utils import absolutify, redirect
 
@@ -205,8 +206,8 @@ def follow_banner_link(request, banner_instance_id):
     except FacebookBannerInstance.DoesNotExist:
         return django_redirect(settings.FACEBOOK_DOWNLOAD_URL)
 
-    # Do not add clicks on HEAD requests.
-    if request.method != 'HEAD':
+    # Do not add a click if the request is from the Facebook bot.
+    if not is_facebook_bot(request):
         add_click.delay(banner_instance_id)
 
     return django_redirect(banner_instance.banner.link)


### PR DESCRIPTION
Fixes an issue where the Facebook bot that grabs data about a page for the Feed dialog would inadvertently add a click to the banner itself.
