### PR TITLE
Add thumbnails to FacebookBanners.

### DIFF
--- a/apps/facebook/forms.py
+++ b/apps/facebook/forms.py
@@ -49,7 +49,7 @@ class BannerFieldRenderer(forms.widgets.RadioFieldRenderer):
             # Construct image tag.
             img = '<img%s>' % flatatt({
                 'class': 'banner-choice',
-                'src': absolutify(banner.image.url),
+                'src': absolutify(banner.thumbnail.url),
                 'width': 100,
                 'height': 72,
                 'alt': banner.alt_text

--- a/apps/facebook/migrations/0019_auto__add_field_facebookbanner_thumbnail.py
+++ b/apps/facebook/migrations/0019_auto__add_field_facebookbanner_thumbnail.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'FacebookBanner.thumbnail'
+        db.add_column('facebook_facebookbanner', 'thumbnail',
+                      self.gf('django.db.models.fields.files.ImageField')(default='', max_length=250, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'FacebookBanner.thumbnail'
+        db.delete_column('facebook_facebookbanner', 'thumbnail')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'facebook.facebookaccountlink': {
+            'Meta': {'object_name': 'FacebookAccountLink'},
+            'activation_code': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'affiliates_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'account_links'", 'to': "orm['auth.User']"}),
+            'facebook_user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'_account_link'", 'unique': 'True', 'to': "orm['facebook.FacebookUser']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'facebook.facebookbanner': {
+            'Meta': {'object_name': 'FacebookBanner'},
+            '_alt_text': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '250'}),
+            'link': ('django.db.models.fields.URLField', [], {'default': "'https://www.mozilla.org/firefox'", 'max_length': '200'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "'Banner'", 'unique': 'True', 'max_length': '255'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'default': "''", 'max_length': '250', 'blank': 'True'})
+        },
+        'facebook.facebookbannerinstance': {
+            'Meta': {'object_name': 'FacebookBannerInstance'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['facebook.FacebookBanner']"}),
+            'can_be_an_ad': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'custom_image': ('django.db.models.fields.files.ImageField', [], {'default': "''", 'max_length': '250', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'processed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'review_status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '90'}),
+            'total_clicks': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'banner_instance_set'", 'to': "orm['facebook.FacebookUser']"})
+        },
+        'facebook.facebookbannerlocale': {
+            'Meta': {'object_name': 'FacebookBannerLocale'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locale_set'", 'to': "orm['facebook.FacebookBanner']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('shared.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'})
+        },
+        'facebook.facebookclickstats': {
+            'Meta': {'object_name': 'FacebookClickStats'},
+            'banner_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['facebook.FacebookBannerInstance']"}),
+            'clicks': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'hour': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 8, 28, 0, 0)'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'facebook.facebookuser': {
+            'Meta': {'object_name': 'FacebookUser'},
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'primary_key': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'leaderboard_position': ('django.db.models.fields.IntegerField', [], {'default': '-1'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'total_clicks': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        }
+    }
+
+    complete_apps = ['facebook']

--- a/apps/facebook/migrations/0020_populate_thumbnails.py
+++ b/apps/facebook/migrations/0020_populate_thumbnails.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+import os
+from shutil import copyfile
+
+from django.conf import settings
+from django.template.defaultfilters import slugify
+
+from south.v2 import DataMigration
+
+
+# Duplicate renaming logic in case it changes after this migration is committed.
+def _generate_banner_filename(instance, filename):
+    extension = os.path.splitext(filename)[1]
+    return '{0}{1}'.format(slugify(instance.name), extension)
+
+
+def fb_banner_thumbnail_rename(instance, filename):
+    new_filename = 'thumb_%s' % _generate_banner_filename(instance, filename)
+    return os.path.join(settings.FACEBOOK_BANNER_IMAGE_PATH, new_filename)
+
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        """
+        Copy current image for FacebookBanner to their thumbnail
+        fields.
+        """
+        for banner in orm['facebook.FacebookBanner'].objects.all():
+            filename = fb_banner_thumbnail_rename(banner, banner.image.name)
+            copyfile(os.path.join(settings.MEDIA_ROOT, banner.image.name),
+                     os.path.join(settings.MEDIA_ROOT, filename))
+            banner.thumbnail = filename
+            banner.save()
+
+    def backwards(self, orm):
+        """Empty out thumbnail field for FacebookBanner."""
+        for banner in orm['facebook.FacebookBanner'].objects.all():
+            banner.thumbnail.delete()
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'facebook.facebookaccountlink': {
+            'Meta': {'object_name': 'FacebookAccountLink'},
+            'activation_code': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'affiliates_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'account_links'", 'to': "orm['auth.User']"}),
+            'facebook_user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'_account_link'", 'unique': 'True', 'to': "orm['facebook.FacebookUser']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'facebook.facebookbanner': {
+            'Meta': {'object_name': 'FacebookBanner'},
+            '_alt_text': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '250'}),
+            'link': ('django.db.models.fields.URLField', [], {'default': "'https://www.mozilla.org/firefox'", 'max_length': '200'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "'Banner'", 'unique': 'True', 'max_length': '255'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'default': "''", 'max_length': '250', 'blank': 'True'})
+        },
+        'facebook.facebookbannerinstance': {
+            'Meta': {'object_name': 'FacebookBannerInstance'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['facebook.FacebookBanner']"}),
+            'can_be_an_ad': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'custom_image': ('django.db.models.fields.files.ImageField', [], {'default': "''", 'max_length': '250', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'processed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'review_status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '90'}),
+            'total_clicks': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'banner_instance_set'", 'to': "orm['facebook.FacebookUser']"})
+        },
+        'facebook.facebookbannerlocale': {
+            'Meta': {'object_name': 'FacebookBannerLocale'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locale_set'", 'to': "orm['facebook.FacebookBanner']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('shared.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'})
+        },
+        'facebook.facebookclickstats': {
+            'Meta': {'object_name': 'FacebookClickStats'},
+            'banner_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['facebook.FacebookBannerInstance']"}),
+            'clicks': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'hour': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 8, 28, 0, 0)'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'facebook.facebookuser': {
+            'Meta': {'object_name': 'FacebookUser'},
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'primary_key': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'leaderboard_position': ('django.db.models.fields.IntegerField', [], {'default': '-1'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'total_clicks': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        }
+    }
+
+    complete_apps = ['facebook']
+    symmetrical = True

--- a/apps/facebook/models.py
+++ b/apps/facebook/models.py
@@ -119,10 +119,19 @@ class FacebookAccountLink(CachingMixin, ModelBase):
         return unicode(self.id) + 'active' if self.is_active else 'inactive'
 
 
+def _generate_banner_filename(instance, filename):
+    extension = os.path.splitext(filename)[1]
+    return '{0}{1}'.format(slugify(instance.name), extension)
+
+
 def fb_banner_rename(instance, filename):
     """Determine the filename for FacebookBanner images."""
-    extension = os.path.splitext(filename)[1]
-    new_filename = '{0}{1}'.format(slugify(instance.name), extension)
+    new_filename = _generate_banner_filename(instance, filename)
+    return os.path.join(settings.FACEBOOK_BANNER_IMAGE_PATH, new_filename)
+
+
+def fb_banner_thumbnail_rename(instance, filename):
+    new_filename = 'thumb_%s' % _generate_banner_filename(instance, filename)
     return os.path.join(settings.FACEBOOK_BANNER_IMAGE_PATH, new_filename)
 
 
@@ -130,11 +139,14 @@ class FacebookBanner(CachingMixin, ModelBase):
     """A banner that users can customize and share on Facebook."""
     name = models.CharField(max_length=255, default='Banner', unique=True,
                             verbose_name='Banner name')
+    _alt_text = models.CharField(max_length=256, blank=True, default='')
+    link = models.URLField(default=settings.FACEBOOK_DOWNLOAD_URL)
     image = models.ImageField(upload_to=fb_banner_rename,
                               storage=OverwritingStorage(),
                               max_length=settings.MAX_FILEPATH_LENGTH)
-    _alt_text = models.CharField(max_length=256, blank=True, default='')
-    link = models.URLField(default=settings.FACEBOOK_DOWNLOAD_URL)
+    thumbnail = models.ImageField(upload_to=fb_banner_thumbnail_rename,
+                                  storage=OverwritingStorage(),
+                                  max_length=settings.MAX_FILEPATH_LENGTH)
 
     objects = CachingManager()
 

--- a/apps/facebook/tests/__init__.py
+++ b/apps/facebook/tests/__init__.py
@@ -72,6 +72,7 @@ class FacebookBannerFactory(Factory):
     FACTORY_FOR = models.FacebookBanner
     name = Sequence(lambda n: 'test%s' % n)
     image = Sequence(lambda n: 'non-existant-path')
+    thumbnail = Sequence(lambda n: 'non-existant-path')
 
 
 class FacebookBannerLocaleFactory(Factory):

--- a/apps/facebook/tests/test_admin.py
+++ b/apps/facebook/tests/test_admin.py
@@ -26,10 +26,12 @@ class FacebookBannerAdminTests(TestCase):
         """
         url = reverse('admin:facebook_facebookbanner_add')
         image = open(path('images', 'firefox-small.png'), 'r')
+        thumbnail = open(path('images', 'firefox-small.png'), 'r')
         self.client.post(url, {
             'name': 'NewBannerTest',
             'locales': ['en-us', 'fr'],
             'image': image,
+            'thumbnail': thumbnail,
             'link': 'http://mozilla.org'
         })
 

--- a/apps/facebook/tests/test_models.py
+++ b/apps/facebook/tests/test_models.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+
+from mock import patch
+from nose.tools import eq_
+
+from facebook.models import fb_banner_rename, fb_banner_thumbnail_rename
+from facebook.tests import FacebookBannerFactory
+from shared.tests import TestCase
+
+
+@patch.object(settings, 'FACEBOOK_BANNER_IMAGE_PATH', 'simple/path/')
+class FacebookBannerRenameTest(TestCase):
+    def test_fb_banner_rename(self):
+        banner = FacebookBannerFactory.create(name='Test banner')
+        filename = fb_banner_rename(banner, 'test.png')
+        eq_(filename, 'simple/path/test-banner.png')
+
+    def test_fb_banner_thumbnail_rename(self):
+        banner = FacebookBannerFactory.create(name='Test banner')
+        filename = fb_banner_thumbnail_rename(banner, 'test.png')
+        eq_(filename, 'simple/path/thumb_test-banner.png')


### PR DESCRIPTION
Includes useful tests for renaming functions, as well as
migrations for copying the existing images as thumbnails
as well.
