### PR TITLE
Switch mailing list subscription to affiliates.

### DIFF
--- a/apps/users/templates/users/include/register_form.html
+++ b/apps/users/templates/users/include/register_form.html
@@ -30,10 +30,13 @@
     {% endtrans %}
   </label>
 
-  {{ register_form.email_subscribe }}
-  <label for="id_{{ register_form.email_subscribe.html_name }}">
-    {{ _('I wish to receive information and notifications about Firefox and Mozilla via email.') }}
-  </label>
+  {# Email subscriptions are only shown for English locales. #}
+  {% if LANG.startswith('en') %}
+    {{ register_form.email_subscribe }}
+    <label for="id_{{ register_form.email_subscribe.html_name }}">
+      {{ _('I wish to receive information and notifications about Firefox and Mozilla via email.') }}
+    </label>
+  {% endif %}
 
   <button class="register" type="submit">{{ _('Register &raquo;') }}</button>
 </form>

--- a/settings/base.py
+++ b/settings/base.py
@@ -106,7 +106,7 @@ SMUGGLER_FORMAT = 'json_files'
 
 # Email subscription config
 BASKET_URL = 'http://basket.mozilla.com'
-BASKET_NEWSLETTER = 'mozilla-and-you'
+BASKET_NEWSLETTER = 'affiliates'
 
 # CSP Config
 CSP_EXCLUDE_URL_PREFIXES = ('/admin',)


### PR DESCRIPTION
Shows the mailing list checkbox to English users only, and
signs users up for the Affiliates mailing list instead of
Mozilla and You.

Note that the English users only part isn't going to be forever, which is why we're keeping the phrase localized.

fix bug 778974
