### PR TITLE
Activate shortened locales and fix tests.

### DIFF
--- a/apps/facebook/tests/test__utils.py
+++ b/apps/facebook/tests/test__utils.py
@@ -4,6 +4,7 @@ import hmac
 import json
 
 from django.test.client import RequestFactory
+from django.utils.translation import get_language
 
 from mock import patch
 from nose.tools import eq_
@@ -95,15 +96,14 @@ class ActivateLocaleTests(TestCase):
         eq_(request.locale, 'en-us')
 
     @patch_settings(DEV=False, TEST=False, FACEBOOK_LOCALES=('en-us', 'de'))
-    @patch('facebook.utils.get_language', lambda: 'de-de')
     def test_language_code_in_whitelist(self):
         """If only a locale's language code is in the whitelist, use it."""
         request = self.factory.get('/')
         activate_locale(request, 'de-de')
+        eq_(get_language(), 'de')
         eq_(request.locale, 'de')
 
     @patch_settings(DEV=False, TEST=False, FACEBOOK_LOCALES=('en-us', 'fr'))
-    @patch('facebook.utils.get_language', lambda: 'en-us')
     def test_locale_in_whitelist(self):
         """If a locale is in the whitelist, use it."""
         request = self.factory.get('/')
@@ -111,7 +111,6 @@ class ActivateLocaleTests(TestCase):
         eq_(request.locale, 'en-us')
 
     @patch_settings(DEV=False, TEST=True, FACEBOOK_LOCALES=('en-us', 'fr'))
-    @patch('facebook.utils.get_language', lambda: 'en-us')
     def test_testing_dont_set_request_locale(self):
         """If settings.TEST is True, do not set the locale on the request."""
         request = self.factory.get('/')

--- a/apps/facebook/tests/test_auth.py
+++ b/apps/facebook/tests/test_auth.py
@@ -107,7 +107,7 @@ class LoginTests(TestCase):
         request = self.request()
         user = FacebookUserFactory.create(first_name='Unchanged')
 
-        def alter_user(self, user):
+        def alter_user(user):
             user.first_name = 'Changed'
             user.save()
         update_user_info.side_effect = alter_user

--- a/apps/facebook/utils.py
+++ b/apps/facebook/utils.py
@@ -97,6 +97,8 @@ def activate_locale(request, locale):
     lang = get_language()
     if not settings.DEV and lang not in settings.FACEBOOK_LOCALES:
         lang = lang.split('-')[0]
+        tower.activate(lang)
+        lang = get_language()
         if lang not in settings.FACEBOOK_LOCALES:
             lang = 'en-us'
             tower.activate(lang)

--- a/apps/shared/tests/__init__.py
+++ b/apps/shared/tests/__init__.py
@@ -132,4 +132,5 @@ def patch_settings(**new_settings):
                 patches.append(patch.object(settings, name, value))
             with nested(*patches):
                 return f(*args, **kwargs)
+        return wrapped
     return decorator


### PR DESCRIPTION
activate_locale now activates the shortened version of
a locale so that get_language returns the exact same value
as request.locale. 

In addition, this fixes the patch_settings decorator,
which previously was breaking tests and not running them.
