### PR TITLE
Fix bug 806466: Use proper placeholders for month-year-picker urls.

### DIFF
--- a/apps/badges/templates/badges/include/sidebar_profile.html
+++ b/apps/badges/templates/badges/include/sidebar_profile.html
@@ -9,9 +9,7 @@
   {% if user_has_created_badges %}
     <div class="statistics-summary">
       <h3>{{ _('Your Statistics Summary') }}</h3>
-      {# Because url can't take placeholders, we use 0 in the months spot
-         and 1 in the year spot. #}
-      {{ month_year_picker(url('badges.ajax.stats', 0, 1)) }}
+      {{ month_year_picker(url('badges.ajax.stats', ':month:', ':year:')) }}
       <div class="instructions">
         {{ _('You can filter results by selecting a specific month using the calendar above.') }}
       </div>

--- a/apps/badges/urls.py
+++ b/apps/badges/urls.py
@@ -6,5 +6,5 @@ urlpatterns = patterns('badges.views',
     url(r'^new$', 'new_badge_step1', name='badges.new.step1'),
     url(r'^new/(?P<subcategory_pk>\d+)$', 'new_badge_step2',
         name='badges.new.step2'),
-    url(r'^stats/(\d+)/(\d+)$', 'month_stats_ajax', name='badges.ajax.stats'),
+    url(r'^stats/(\d+|:month:)/(\d+|:year:)$', 'month_stats_ajax', name='badges.ajax.stats'),
 )

--- a/apps/facebook/templates/facebook/base.html
+++ b/apps/facebook/templates/facebook/base.html
@@ -124,8 +124,7 @@
 
           <h3>{{ _('Your Statistics Summary') }}</h3>
           <div class="calendar">
-            {# Because url can't take placeholders, we use 0 in the months spot and 1 in the year spot. #}
-            {{ month_year_picker(url('facebook.stats', 1, 0)) }}
+            {{ month_year_picker(url('facebook.stats', ':year:', ':month:')) }}
           </div>
           <p class="note">{{ _('You can filter results by selecting a specific month using the calendar above.') }}</p>
           <p class="total">{{ _('Total clicks') }} <strong id="total-clicks">0</strong></p>

--- a/apps/facebook/tests/test_views.py
+++ b/apps/facebook/tests/test_views.py
@@ -476,3 +476,23 @@ class BannerDeleteTests(TestCase):
         instance = FacebookBannerInstanceFactory.create(user=self.user)
         self._delete(banner_instance=instance.id)
         ok_(not FacebookBannerInstance.objects.filter(id=instance.id).exists())
+
+
+class StatsTests(TestCase):
+    def setUp(self):
+        self.user = FacebookUserFactory.create()
+        self.client.fb_login(self.user)
+
+    def _stats(self, year, month):
+        with self.activate('en-US'):
+            return self.client.get(reverse('facebook.stats',
+                                           args=[year, month]))
+
+    def test_placeholder_400(self):
+        """
+        If a placeholder value is used for the year or month, return a 400 Bad
+        Request.
+        """
+        eq_(self._stats(':year:', 2).status_code, 400)
+        eq_(self._stats(2012, ':month:').status_code, 400)
+        eq_(self._stats(':year:', ':month:').status_code, 400)

--- a/apps/facebook/urls.py
+++ b/apps/facebook/urls.py
@@ -48,7 +48,7 @@ urlpatterns = patterns('facebook.views',
     url(r'^newsletter/subscribe/?$', views.newsletter_subscribe,
         name='facebook.newsletter.subscribe'),
 
-    url(r'^stats/(\d+)/(\d+)/?$', views.stats, name='facebook.stats'),
+    url(r'^stats/(\d+|:year:)/(\d+|:month:)/?$', views.stats, name='facebook.stats'),
 
     url(r'^deauthorize/?$', views.deauthorize, name='facebook.deauthorize'),
 

--- a/apps/facebook/views.py
+++ b/apps/facebook/views.py
@@ -329,6 +329,10 @@ def stats(request, year, month):
     """
     Returns statistics for the sidebar statistics display. Called via AJAX.
     """
+    # Check for placeholder values and return a 400 if they are present.
+    if month == ':month:' or year == ':year:':
+        return JSONResponseBadRequest({'error': 'Invalid year/month value.'})
+
     clicks = FacebookClickStats.objects.total_for_month(request.user, year,
                                                         month)
     return JSONResponse({'clicks': clicks})

--- a/media/js/month_year_picker.js
+++ b/media/js/month_year_picker.js
@@ -15,9 +15,6 @@
             this.shortMonthNames = $picker.data('short-month-names');
             this.longMonthNames = $picker.data('long-month-names');
 
-            // Because Django's reverse doesn't allow you to use placeholder
-            // values, we're assuming here that the given url has a value of
-            // 0 in place for the months and 1 for the year. :\
             this.url = options.url || $picker.data('url');
 
             var date = new Date();
@@ -106,7 +103,8 @@
 
             this.updateDisplay();
             $.ajax({
-                url: this.url.replace('0', this.month).replace('1', this.year),
+                url: this.url.replace(':month:', this.month).replace(':year:',
+                                                                     this.year),
                 type: 'get'
             }).done(function(data) {
                 self.$errorMsg.hide();


### PR DESCRIPTION
Updates the urls for both statistics widgets to accept :month: and
:year: placeholders, and updates the corresponding views to send 400
Bad Request responses if the placeholders are passed in.

Then, updates the month-year-picker to expect these placeholders instead
of using 0 and 1 as placeholders, which causes an issue in months and
years that contain a 1 or a 0.
