### PR TITLE
Fix Bug 794624: Add P3P headers to appease IE.

### DIFF
--- a/apps/shared/middleware.py
+++ b/apps/shared/middleware.py
@@ -6,3 +6,10 @@ class ExceptionLoggingMiddleware(object):
     def process_exception(self, request, exception):
         import traceback
         print traceback.format_exc()
+
+
+class PrivacyMiddleware(object):
+    """Adds P3P policy headers to responses."""
+    def process_response(self, request, response):
+        response['P3P'] = 'CP="This is not a P3P policy!"'
+        return response

--- a/media/js/facebook/redirect.js
+++ b/media/js/facebook/redirect.js
@@ -1,8 +1,9 @@
 (function() {
     var target = window;
-    if (document.body.dataset.topWindow) {
+    var $body = $(document.body);
+    if ($body.data('topWindow')) {
         target = window.top;
     }
 
-    target.location = document.body.dataset.url;
+    target.location = $body.data('url');
 })();

--- a/settings/base.py
+++ b/settings/base.py
@@ -211,6 +211,7 @@ MINIFY_BUNDLES = {
             'js/facebook/banner_create.js',
         ),
         'fb_redirect': (
+            'js/libs/jquery-1.7.1.js',
             'js/facebook/redirect.js',
         ),
         'fb_banner_list': (
@@ -249,6 +250,7 @@ MIDDLEWARE_CLASSES = [
     'commonware.middleware.StrictTransportMiddleware',
     'commonware.middleware.ScrubRequestOnException',
     'csp.middleware.CSPMiddleware',
+    'shared.middleware.PrivacyMiddleware',
 ]
 
 # Facebook auth middleware needs to come after AuthMiddleware but before


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=794624 we're using bogus P3P headers. No tests as the functionality is trivial.

Also includes a small JS fix; turns out data attributes aren't as widely supported as I thought, so we use jQuery to handle the incompatible browsers for JS redirects.
