### PR TITLE
Fix bug 896423: Update our usage of the Facebook Send Dialog.

### DIFF
--- a/apps/facebook/templates/facebook/invite.html
+++ b/apps/facebook/templates/facebook/invite.html
@@ -2,9 +2,6 @@
 <html>
   <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
   <body data-app-id="{{ FACEBOOK_APP_ID }}"
-        data-picture="{{ absolutify([MEDIA_URL, 'img/facebook/fx-logo-lg.png']|join('')) }}"
-        data-name="{{ _('Mozilla Firefox') }}"
-        data-description="{{ _('Different by design. It\'s fast, flexible and secure. Share Firefox with your friends today.') }}"
         data-link="{{ FACEBOOK_DOWNLOAD_URL }}"
         data-next="{{ next }}">
     {{ js('fb_invite') }}

--- a/apps/facebook/views.py
+++ b/apps/facebook/views.py
@@ -300,8 +300,9 @@ def post_invite(request):
     Redirect user back to the app after they've invited friends to download
     Firefox.
     """
-    messages.success(request, _('You have successfully sent a message to one '
-                                'of your friends!'))
+    if request.GET.get('success', None):
+        messages.success(request, _('You have successfully sent a message to one of your '
+                                    'friends!'))
     return django_redirect(settings.FACEBOOK_APP_URL)
 
 

--- a/media/js/facebook/invite.js
+++ b/media/js/facebook/invite.js
@@ -6,9 +6,6 @@
 
     var params = $.param({
         app_id: $body.data('appId'),
-        picture: $body.data('picture'),
-        name: $body.data('name'),
-        description: $body.data('description'),
         link: $body.data('link'),
         redirect_uri: $body.data('next')
     });

--- a/settings/test.py
+++ b/settings/test.py
@@ -6,6 +6,7 @@ CACHES = {
 }
 
 SITE_URL = 'http://badge.mo.com'
+SITE_ID = 1
 
 # Speed up tests.
 PASSWORD_HASHERS = (


### PR DESCRIPTION
We actually are compliant with the October 2013 Breaking Changes, but
this removes the excess parameters anyway. This also fixes the 
post-invite view to correctly detect if the user sent a message or if
they cancelled out of the invitation process.

Also adds SITE_ID = 1 to the test settings to make the tests work even
if you've set SITE_ID to something else in your local settings. 
Otherwise the tests might attempt to fetch a SITE_ID besides 1, which
doesn't exist in the test database.
