### PR TITLE
Bug 705569 - [affiliates][l10n]`Statics instead` of `statistics` in en-US

### DIFF
--- a/apps/badges/templates/badges/include/leaderboard.html
+++ b/apps/badges/templates/badges/include/leaderboard.html
@@ -14,7 +14,7 @@
           <br>
           Where are you on the leaderboard?
           <br>
-          Leaderboard statics are updated at midnight PT each day.
+          Leaderboard statistics are updated at midnight PT each day.
         {% endtrans %}
       </p>
     </div>


### PR DESCRIPTION
modified the word from 'statics' to 'statistics'
