### PR TITLE
Fix various issues around setting up a new dev instance of the site.

### DIFF
--- a/affiliates/facebook/middleware.py
+++ b/affiliates/facebook/middleware.py
@@ -1,16 +1,8 @@
-import base64
-
-from django.conf import settings
-
-import jingo
 from funfactory.urlresolvers import Prefixer
-from mock import patch
 
 from affiliates.facebook.auth import SESSION_KEY
 from affiliates.facebook.models import AnonymousFacebookUser, FacebookUser
-from affiliates.facebook.tests import create_payload
 from affiliates.facebook.utils import activate_locale, in_facebook_app
-from affiliates.facebook.views import load_app
 
 
 class FacebookAuthenticationMiddleware(object):
@@ -39,63 +31,3 @@ class FacebookAuthenticationMiddleware(object):
             locale = prefixer.get_language()
 
         activate_locale(request, locale)
-
-
-class FacebookDebugMiddleware(object):
-    """
-    If FACEBOOK_DEBUG is True, this middleware changes the Facebook app
-    parts of the site to be displayed in an iframe and auto-auths the user as
-    the Facebook user with the ID specified in settings.FACEBOOK_DEBUG_USER_ID.
-    """
-    def __init__(self):
-        self.decode_patcher = None
-
-        # Mock out CSP_FRAME_SRC to allow data URI in iframe.
-        new_csp_frame_src = list(settings.CSP_FRAME_SRC) + ['data:']
-        self.csp_patcher = patch.object(settings, 'CSP_FRAME_SRC',
-                                        new_csp_frame_src)
-
-        # Mock out decode function for authentication.
-        self.decode_patcher = patch('affiliates.facebook.views.decode_signed_request')
-
-    def process_request(self, request):
-        request._fb_debug = (getattr(settings, 'FACEBOOK_DEBUG', False) and
-                             in_facebook_app(request))
-
-    def process_view(self, request, view_func, view_args, view_kwargs):
-        """Mock in signed_request if user is viewing the login view."""
-        if not request._fb_debug:
-            return None
-
-        # Add patcher to requests to avoid stopping them when they haven't
-        # started.
-        request.csp_patcher = self.csp_patcher
-        request.csp_patcher.start()
-
-        user_id = getattr(settings, 'FACEBOOK_DEBUG_USER_ID', None)
-        if view_func == load_app and user_id:
-            request.method = 'POST'
-            post = request.POST.copy()
-            post['signed_request'] = 'signed_request'
-            request.POST = post
-
-            request.decode_patcher = self.decode_patcher
-            decode_mock = request.decode_patcher.start()
-            decode_mock.return_value = create_payload(user_id=user_id)
-
-    def process_response(self, request, response):
-        """Add an iframe wrapper and deactivate decode patch."""
-        if not request._fb_debug:
-            return response
-
-        if getattr(request, 'csp_patcher', False):
-            request.csp_patcher.stop()
-
-        if getattr(request, 'decode_patcher', False):
-            request.decode_patcher.stop()
-
-        # Use a base64 data URI to shove the response content into an iframe.
-        template = jingo.env.get_template('facebook/debug_wrapper.html')
-        content = base64.b64encode(response.content)
-        response.content = template.render(content=content)
-        return response

--- a/affiliates/settings/__init__.py
+++ b/affiliates/settings/__init__.py
@@ -10,22 +10,6 @@ except ImportError, exc:
     raise exc
 
 
-# Lazily evaluate MIDDLEWARE_CLASSES in order to add middleware based on
-# settings like DEBUG or DEV.
-# We do this here instead of base.py to avoid having to refer to
-# STATIC_MIDDLEWARE_CLASSES everywhere in settings instead of the default.
-def lazy_middleware_classes():
-    from django.conf import settings
-    middleware = settings.STATIC_MIDDLEWARE_CLASSES
-
-    if settings.DEBUG and not settings.TEST:
-        middleware.insert(0, 'affiliates.facebook.middleware.FacebookDebugMiddleware')
-
-    return middleware
-STATIC_MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES[:]
-MIDDLEWARE_CLASSES = lazy(lazy_middleware_classes, list)()
-
-
 # Import test settings
 TEST = len(sys.argv) > 1 and sys.argv[1] == 'test'
 if TEST:

--- a/affiliates/settings/base.py
+++ b/affiliates/settings/base.py
@@ -143,6 +143,7 @@ JINGO_EXCLUDE_APPS = [
     'smuggler',
     'stats',
     'fb',
+    'registration',
 ]
 
 # Activate statsd patches to time database and cache hits.

--- a/affiliates/settings/test.py
+++ b/affiliates/settings/test.py
@@ -20,3 +20,9 @@ PASSWORD_HASHERS = (
 # tests, jingo-minify will generate the wrong path to static media due
 # to Django forcing DEBUG to be False during tests.
 TEMPLATE_DEBUG = False
+
+
+# Filler settings to make the Facebook app tests happy.
+FACEBOOK_APP_ID = '000000000000000'
+FACEBOOK_APP_SECRET = 'its.a.secret.to.everybody'
+FACEBOOK_APP_NAMESPACE = 'local.affiliates.test.app'

--- a/affiliates/users/models.py
+++ b/affiliates/users/models.py
@@ -18,7 +18,14 @@ def add_default_permissions(sender, **kwargs):
     """Add default set of permissions to users when they are first created."""
     if kwargs['created']:
         user = kwargs['instance']
-        can_share_website = Permission.objects.get(codename='can_share_website')
+
+        try:
+            can_share_website = Permission.objects.get(codename='can_share_website')
+        except Permission.DoesNotExist:
+            # Permission will be created by migration and thus doesn't
+            # need to be added now.
+            return
+
         user.user_permissions.add(can_share_website)
         user.save()
 

--- a/affiliates/users/tests/test_models.py
+++ b/affiliates/users/tests/test_models.py
@@ -1,0 +1,47 @@
+from django.contrib.auth.models import Permission, User
+
+from mock import patch
+from nose.tools import ok_
+
+from affiliates.base.tests import TestCase
+from affiliates.users.models import add_default_permissions
+from affiliates.users.tests import UserFactory
+
+
+class AddDefaultPermissionsTests(TestCase):
+    def setUp(self):
+        self.can_share_website = Permission.objects.get(codename='can_share_website')
+
+    def test_not_created(self):
+        """If user is not new, don't bother with permissions."""
+        user = UserFactory.create()
+        user.user_permissions.clear()
+
+        add_default_permissions(User, created=False, instance=user)
+        ok_(self.can_share_website not in user.user_permissions.all())
+
+    def test_permission_doesnt_exist(self):
+        """
+        If the can_share_website permission isn't created yet, do
+        nothing.
+        """
+        user = UserFactory.create()
+        user.user_permissions.clear()
+
+        with patch('affiliates.users.models.Permission') as MockPermission:
+            MockPermission.DoesNotExist = Exception
+            MockPermission.objects.get.side_effect = MockPermission.DoesNotExist
+
+            add_default_permissions(User, created=True, instance=user)
+            ok_(self.can_share_website not in user.user_permissions.all())
+
+    def test_permission_granted(self):
+        """
+        Newly created users should be granted the can_share_website
+        permission.
+        """
+        user = UserFactory.create()
+        user.user_permissions.clear()
+
+        add_default_permissions(User, created=True, instance=user)
+        ok_(self.can_share_website in user.user_permissions.all())

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,10 +30,11 @@ have ``pip`` installed, you can install it with ``easy_install pip``.
 3. Set up a local MySQL database. The `MySQL Installation Documentation`_
    explains this fairly well.
 
-4. Configure your local settings by copying ``settings/local.py-dist`` to
-   ``settings/local.py`` and customizing the settings in it::
+4. Configure your local settings by copying
+   ``affiliates/settings/local.py-dist`` to ``affiliates/settings/local.py``
+   and customizing the settings in it::
 
-    $ cp settings/local.py-dist settings/local.py
+    $ cp affiliates/settings/local.py-dist affiliates/settings/local.py
 
    The file is commented to explain what each setting does and how to customize
    them.


### PR DESCRIPTION
- Add registration to JINGO_EXCLUDE_APPS to prevent admin logout
  template from being rendered by Jinja.
- Update signal for default permissions to abort if the
  can_share_website permission doesn't exist yet, which occurs when
  creating an admin during the initial syncdb. Also adds tests for this
  signal.
- Update install docs to have correct paths.
- Remove FacebookDebugMiddleware; Facebook app testing can be done with
  a test app, and it causes import issues.
