### PR TITLE
Bug 993237: Add aggregation command and overwrite old stats upon update.

### DIFF
--- a/affiliates/links/management/commands/aggregate_old_datapoints.py
+++ b/affiliates/links/management/commands/aggregate_old_datapoints.py
@@ -1,0 +1,34 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.db.models import F
+from django.utils import timezone
+
+from affiliates.links.models import DataPoint, Link
+
+
+class Command(BaseCommand):
+    help = ('Aggregate DataPoints older than 90 days.')
+
+    def handle(self, *args, **kwargs):
+        today = timezone.now().date()
+        cutoff = today - timedelta(days=90)
+
+        datapoints = DataPoint.objects.filter(date__lt=cutoff)
+        total = datapoints.count()
+        print 'Aggregating old datapoints... (0/{0})'.format(total)
+        for index, datapoint in enumerate(datapoints):
+            if index % 1000 == 0:
+                print 'Aggregating old datapoints... ({0}/{1})'.format(index, total)
+
+            Link.objects.filter(pk=datapoint.link.pk).update(
+                aggregate_link_clicks=F('aggregate_link_clicks') + datapoint.link_clicks,
+                aggregate_firefox_downloads=(F('aggregate_firefox_downloads') +
+                                             datapoint.firefox_downloads),
+            )
+
+            # Bulk delete would be nicer, but this helps avoid stat
+            # errors if we re-run after a failure.
+            datapoint.delete()
+
+        print 'Done!'

--- a/affiliates/links/management/commands/collect_ga_data.py
+++ b/affiliates/links/management/commands/collect_ga_data.py
@@ -1,5 +1,7 @@
+from datetime import datetime
+
 from django.core.management.base import BaseCommand, CommandError
-from django.db import IntegrityError
+from django.utils import timezone
 
 from affiliates.base.utils import date_yesterday
 from affiliates.links.google_analytics import AnalyticsError, AnalyticsService
@@ -7,19 +9,29 @@ from affiliates.links.models import DataPoint, Link
 
 
 class Command(BaseCommand):
-    help = ('Collect metrics from Google Analytics for the previous day.')
+    help = ('Collect metrics from Google Analytics for the given day (format DD-MM-YYYY, defaults '
+            'to yesterday if no date is given, uses UTC timezone).')
+    args = '[date]'
 
-    def handle(self, *args, **kwargs):
+    def handle(self, query_date=None, *args, **kwargs):
         try:
             service = AnalyticsService()
         except AnalyticsError as e:
             raise CommandError('Could not connect to analytics service: {0}'.format(e), e)
 
-        yesterday = date_yesterday()
+        if query_date:
+            try:
+                unaware_query_datetime = datetime.strptime(query_date, '%d-%m-%Y')
+            except ValueError:
+                raise CommandError('Date argument invalid. It must be in DD-MM-YYYY format')
+
+            query_date = timezone.make_aware(unaware_query_datetime, timezone.utc).date()
+        else:
+            query_date = date_yesterday()
 
         print 'Downloading click counts from GA...'
         try:
-            clicks = service.get_clicks_for_date(yesterday)
+            clicks = service.get_clicks_for_date(query_date)
         except AnalyticsError as e:
             raise CommandError('Could not retrieve click data from analytics service: {0}'
                                .format(e))
@@ -27,13 +39,13 @@ class Command(BaseCommand):
         print 'Adding datapoints to database...'
         datapoints = []
         for pk in Link.objects.values_list('id', flat=True):
-            datapoint = DataPoint(link_id=pk, date=yesterday,
+            datapoint = DataPoint(link_id=pk, date=query_date,
                                   link_clicks=clicks.get(unicode(pk), 0))
             datapoints.append(datapoint)
 
-        try:
-            DataPoint.objects.bulk_create(datapoints, batch_size=1000)
-        except IntegrityError as e:
-            raise CommandError('Could not insert datapoints into database due to IntegrityError.', e)
+        # Remove existing data, because supposedly our data is more
+        # up-to-date.
+        DataPoint.objects.filter(date=query_date).delete()
+        DataPoint.objects.bulk_create(datapoints)
 
         print 'Done!'


### PR DESCRIPTION
- Adds a command for aggregating clicks and downloads that are older 
  than 90 days.
- Updates the collect_ga_data command to accept a date argument for
  easier testing, and to overwrite existing stats instead of raising
  an error due to unique constraints.
