### PR TITLE
Show previews of banners in generator and links on dashboard.

### DIFF
--- a/affiliates/banners/migrations/0004_auto__add_field_firefoxupgradebannervariation_width__add_field_firefox.py
+++ b/affiliates/banners/migrations/0004_auto__add_field_firefoxupgradebannervariation_width__add_field_firefox.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'FirefoxUpgradeBannerVariation.width'
+        db.add_column(u'banners_firefoxupgradebannervariation', 'width',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(default=0),
+                      keep_default=False)
+
+        # Adding field 'FirefoxUpgradeBannerVariation.height'
+        db.add_column(u'banners_firefoxupgradebannervariation', 'height',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(default=0),
+                      keep_default=False)
+
+        # Adding field 'ImageBannerVariation.width'
+        db.add_column(u'banners_imagebannervariation', 'width',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(default=0),
+                      keep_default=False)
+
+        # Adding field 'ImageBannerVariation.height'
+        db.add_column(u'banners_imagebannervariation', 'height',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(default=0),
+                      keep_default=False)
+
+    def backwards(self, orm):
+        # Deleting field 'FirefoxUpgradeBannerVariation.width'
+        db.delete_column(u'banners_firefoxupgradebannervariation', 'width')
+
+        # Deleting field 'FirefoxUpgradeBannerVariation.height'
+        db.delete_column(u'banners_firefoxupgradebannervariation', 'height')
+
+        # Deleting field 'ImageBannerVariation.width'
+        db.delete_column(u'banners_imagebannervariation', 'width')
+
+        # Deleting field 'ImageBannerVariation.height'
+        db.delete_column(u'banners_imagebannervariation', 'height')
+
+
+    models = {
+        u'banners.category': {
+            'Meta': {'object_name': 'Category'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['banners.Category']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'banners.firefoxupgradebanner': {
+            'Meta': {'object_name': 'FirefoxUpgradeBanner'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['banners.Category']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'destination': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'banners.firefoxupgradebannervariation': {
+            'Meta': {'object_name': 'FirefoxUpgradeBannerVariation'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variation_set'", 'to': u"orm['banners.FirefoxUpgradeBanner']"}),
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '255'}),
+            'locale': ('affiliates.base.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'upgrade_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '255'}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'banners.imagebanner': {
+            'Meta': {'object_name': 'ImageBanner'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['banners.Category']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'destination': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'banners.imagebannervariation': {
+            'Meta': {'object_name': 'ImageBannerVariation'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variation_set'", 'to': u"orm['banners.ImageBanner']"}),
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '255'}),
+            'locale': ('affiliates.base.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'banners.textbanner': {
+            'Meta': {'object_name': 'TextBanner'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['banners.Category']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'destination': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'banners.textbannervariation': {
+            'Meta': {'object_name': 'TextBannerVariation'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variation_set'", 'to': u"orm['banners.TextBanner']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('affiliates.base.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        }
+    }
+
+    complete_apps = ['banners']

--- a/affiliates/banners/migrations/0005_populate_variation_dimensions.py
+++ b/affiliates/banners/migrations/0005_populate_variation_dimensions.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from south.v2 import DataMigration
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Re-save variations to update their dimensions.
+        for variation in orm['banners.ImageBannerVariation'].objects.all():
+            variation.width = variation.image.width
+            variation.height = variation.image.height
+            variation.save()
+
+        for variation in orm['banners.FirefoxUpgradeBannerVariation'].objects.all():
+            variation.width = variation.image.width
+            variation.height = variation.image.height
+            variation.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'banners.category': {
+            'Meta': {'object_name': 'Category'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['banners.Category']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'banners.firefoxupgradebanner': {
+            'Meta': {'object_name': 'FirefoxUpgradeBanner'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['banners.Category']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'destination': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'banners.firefoxupgradebannervariation': {
+            'Meta': {'object_name': 'FirefoxUpgradeBannerVariation'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variation_set'", 'to': u"orm['banners.FirefoxUpgradeBanner']"}),
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '255'}),
+            'locale': ('affiliates.base.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'upgrade_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '255'}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'banners.imagebanner': {
+            'Meta': {'object_name': 'ImageBanner'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['banners.Category']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'destination': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'banners.imagebannervariation': {
+            'Meta': {'object_name': 'ImageBannerVariation'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variation_set'", 'to': u"orm['banners.ImageBanner']"}),
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '255'}),
+            'locale': ('affiliates.base.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'banners.textbanner': {
+            'Meta': {'object_name': 'TextBanner'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['banners.Category']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'destination': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'banners.textbannervariation': {
+            'Meta': {'object_name': 'TextBannerVariation'},
+            'banner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variation_set'", 'to': u"orm['banners.TextBanner']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('affiliates.base.models.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        }
+    }
+
+    complete_apps = ['banners']
+    symmetrical = True

--- a/affiliates/banners/templates/banners/generator/banners.html
+++ b/affiliates/banners/templates/banners/generator/banners.html
@@ -21,14 +21,7 @@
 
       <ul class="banners-list">
       {% for banner in banners %}
-        <li class="banner">
-          {# TODO: Add the 'smart banner' flag here if it's a smart banner. #}
-          <a href="{{ banner.get_customize_url() }}">
-            {# TODO: This should be the correct banner preview image, with the blank as fallback. If it's a text banner, this should be the text preview. #}
-            <img class="preview" src="{{ static('img/banner-blank.png') }}" alt="">
-            <h3 class="name">{{ banner.name }}</h3>
-          </a>
-        </li>
+        {{ banner.preview_html(banner.get_customize_url()) }}
       {% endfor %}
       </ul>
 

--- a/affiliates/banners/templates/banners/previews/base.html
+++ b/affiliates/banners/templates/banners/previews/base.html
@@ -1,0 +1,15 @@
+<li class="banner {{ extra_class|default('') }}">
+  {% block flag %}{% endblock %}
+  <a href="{{ href }}">
+    {% block preview %}{% endblock %}
+    {% if link %}
+      <ul class="desc">
+        {% block link_extra %}{% endblock %}
+        <li>Created <time datetime="{{ link.created.isoformat() }}">{{ link.created|babel_date }}</time></li>
+        <li>{{ link.link_clicks|babel_number }} clicks</li>
+      </ul>
+    {% else %}
+      <h3 class="name">{{ banner.name }}</h3>
+    {% endif %}
+  </a>
+</li>

--- a/affiliates/banners/templates/banners/previews/image_banner.html
+++ b/affiliates/banners/templates/banners/previews/image_banner.html
@@ -1,0 +1,9 @@
+{% extends 'banners/previews/base.html' %}
+
+{% block preview %}
+  <img class="preview" src="{{ preview_img|default(static('img/banner-blank.png')) }}" alt="">
+{% endblock %}
+
+{% block link_extra %}
+  <li>{{ link.banner_variation.size }}</li>
+{% endblock %}

--- a/affiliates/banners/templates/banners/previews/text_banner.html
+++ b/affiliates/banners/templates/banners/previews/text_banner.html
@@ -1,0 +1,11 @@
+{% extends 'banners/previews/base.html' %}
+
+{% set extra_class = 'text' %}
+
+{% block preview %}
+  <div class="preview">{{ preview_text|default(_('No preview available.')) }}</div>
+{% endblock %}
+
+{% block link_extra %}
+  <li>{{ _('Text banner') }}</li>
+{% endblock %}

--- a/affiliates/banners/templates/banners/previews/upgrade_banner.html
+++ b/affiliates/banners/templates/banners/previews/upgrade_banner.html
@@ -1,0 +1,8 @@
+{% extends 'banners/previews/image_banner.html' %}
+
+{% set extra_class = 'smart' %}
+
+{% block flag %}
+  {# TODO: Make the help thingie open a modal with an explanation #}
+  <em class="flag">{{ _('Smart') }} <a class="help" href="#" title="{{ _('What are smart banners?') }}">{{ _('What are smart banners?') }}</a></em>
+{% endblock %}

--- a/affiliates/banners/tests/__init__.py
+++ b/affiliates/banners/tests/__init__.py
@@ -1,4 +1,7 @@
+from django.db.models.signals import post_init
+
 from factory import DjangoModelFactory, Sequence, SubFactory
+from factory.django import mute_signals
 
 from affiliates.banners import models
 
@@ -22,6 +25,7 @@ class ImageBannerFactory(BannerFactory):
     FACTORY_FOR = models.ImageBanner
 
 
+@mute_signals(post_init)
 class ImageVariationFactory(DjangoModelFactory):
     ABSTRACT_FACTORY = True
 
@@ -52,6 +56,7 @@ class FirefoxUpgradeBannerFactory(BannerFactory):
     FACTORY_FOR = models.FirefoxUpgradeBanner
 
 
+@mute_signals(post_init)
 class FirefoxUpgradeBannerVariationFactory(ImageVariationFactory):
     FACTORY_FOR = models.FirefoxUpgradeBannerVariation
 

--- a/affiliates/base/templates/base/dashboard.html
+++ b/affiliates/base/templates/base/dashboard.html
@@ -39,20 +39,7 @@
         {% if links %}
           <ul class="banners-list">
             {% for link in links %}
-              <li class="banner {{ link.banner_type }}">
-                {% if link.banner_type == 'smart_banner' %}
-                  {# TODO: Make the help thingie open a modal with an explanation #}
-                  <em class="flag">{{ _('Smart') }} <a class="help" href="#" title="{{ _('What are smart banners?') }}">{{ _('What are smart banners?') }}</a></em>
-                {% endif %}
-                <a href="{{ link.get_absolute_url() }}">
-                  <img class="preview" src="{{ static('img/banner-blank.png') }}" alt="">
-                  <ul class="desc">
-                    <li>125 × 125</li>
-                    <li>Created <time datetime="{{ link.created.isoformat() }}">{{ link.created|babel_date }}</time></li>
-                    <li>{{ link.link_clicks|babel_number }} clicks</li>
-                  </ul>
-                </a>
-              </li>
+              {{ link.preview_html(link.get_absolute_url()) }}
             {% endfor %}
           </ul>
         {% else %}

--- a/affiliates/links/models.py
+++ b/affiliates/links/models.py
@@ -74,6 +74,9 @@ class Link(models.Model):
         from affiliates.banners.models import TextBanner
         return isinstance(self.banner, TextBanner)
 
+    def preview_html(self, href):
+        return self.banner.preview_html(href)
+
     def get_referral_url(self):
         return absolutify(reverse('links.referral', args=[self.pk]))
 


### PR DESCRIPTION
Image banners use a 125x125 variation as their preview, as do upgrade banners. Text banners show the text in a small box. All banners attempt to show a localized preview and fallback to en-US.

The tests use an in-development version of `factory_boy` for a lovely little decorator that mutes signals. Otherwise, the ImageField on variations would be attempting to read files that don't exist in order to populate the width/height fields when models are saved.
