### PR TITLE
Fix bug 1007838: Add views for legacy URLs.

### DIFF
--- a/affiliates/links/urls.py
+++ b/affiliates/links/urls.py
@@ -7,6 +7,9 @@ from affiliates.links import views
 urlpatterns = patterns('',
     url(r'^link/(?P<pk>\d+)/$', views.LinkDetailView.as_view(), name='links.detail'),
     url(r'^referral/(?P<pk>\d+)/$', views.LinkReferralView.as_view(), name='links.referral'),
+    url(r'^link/banner/(?P<pk>\d+)$', views.LinkReferralView.as_view()),
+    url(r'^link/banner/(?P<user_id>\d+)/(?P<banner_id>\d+)/(?P<banner_img_id>\d+)$',
+        views.LegacyLinkReferralView.as_view()),
 
     url(r'^leaderboard/$', TemplateView.as_view(template_name='links/leaderboard.html'),
         name='links.leaderboard'),

--- a/affiliates/links/views.py
+++ b/affiliates/links/views.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.views.generic import DetailView
 
 from braces.views import LoginRequiredMixin
@@ -22,3 +23,13 @@ class LinkReferralView(DetailView):
     @csp_exempt
     def dispatch(self, *args, **kwargs):
         return super(LinkReferralView, self).dispatch(*args, **kwargs)
+
+
+class LegacyLinkReferralView(LinkReferralView):
+    def get_object(self, queryset=None):
+        links = Link.objects.filter(user__id=self.kwargs['user_id'],
+                                    legacy_banner_image_id=self.kwargs['banner_img_id'])
+        if not links:
+            raise Http404()
+        else:
+            return links[0]


### PR DESCRIPTION
See https://github.com/mozilla/affiliates/blob/v1.0/apps/banners/urls.py
for examples of what old banner links look like.
