### PR TITLE
collect_ga_data Updates

### DIFF
--- a/affiliates/links/management/commands/collect_ga_data.py
+++ b/affiliates/links/management/commands/collect_ga_data.py
@@ -4,7 +4,6 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 
 from affiliates.base.management.commands import QuietCommand
-from affiliates.base.utils import date_yesterday
 from affiliates.links.google_analytics import AnalyticsError, AnalyticsService
 from affiliates.links.models import DataPoint, Link
 
@@ -20,7 +19,9 @@ class Command(QuietCommand):
         except AnalyticsError as e:
             raise CommandError('Could not connect to analytics service: {0}'.format(e), e)
 
-        if query_date:
+        if query_date == 'today':
+            query_date = timezone.now().date()
+        elif query_date:
             try:
                 unaware_query_datetime = datetime.strptime(query_date, '%d-%m-%Y')
             except ValueError:
@@ -28,7 +29,7 @@ class Command(QuietCommand):
 
             query_date = timezone.make_aware(unaware_query_datetime, timezone.utc).date()
         else:
-            query_date = date_yesterday() - timedelta(days=1)
+            query_date = timezone.now() - timedelta(days=2)
 
         self.output('Downloading click counts from GA...')
         try:


### PR DESCRIPTION
Makes two changes to `collect_ga_data`:
- Changes the default date of collection from yesterday to two days ago. Currently, we run the nightly update at 23:00 UTC, but GA takes up to 24 hours to get click data up. This means that clicks between 23:00 UTC and midnight may not be available in the API by the time we run the collection the next day. Instead, we should run the command at 0:30 UTC and have it collect from two days prior; this will ensure at least 24 hours between click time and collection time.
- Adds `today` as a valid date argument. This will let us add an extra cronjob to dev that runs collection for the current day every 15 minutes, which will make testing click collection on dev a bit faster.
