### PR TITLE
Bug 1008447: Add CachingMixin and CacheManager to User class.

### DIFF
--- a/affiliates/users/models.py
+++ b/affiliates/users/models.py
@@ -34,11 +34,14 @@ def user_leaderboard_rank(self, metric):
 User.add_to_class('leaderboard_rank', user_leaderboard_rank)
 
 
-class AffiliatesUserManager(UserManager):
+class AffiliatesUserManager(CachingManager, UserManager):
     # UserManager that prefetches user profiles when getting users.
     def get_query_set(self):
         return super(AffiliatesUserManager, self).get_query_set().select_related('userprofile')
 User.add_to_class('objects', AffiliatesUserManager())
+
+# Add CachingMixin to User's base classes so that it can be cached.
+User.__bases__ = (CachingMixin,) + User.__bases__
 
 
 @receiver(models.signals.post_save, sender=User)


### PR DESCRIPTION
When a new link is created, the cached results for a user’s links
doesn’t get invalidated because, while the link has a foreign key to the
user, the user isn’t cached by django-cache-machine. By adding the mixin
and manager to the user class, when a new link is created, the user, and
thus it’s related links, should be invalidated, fixing the caching 
issues on the dashboard.
