### PR TITLE
Bug 1014273: Do not cache CSRF token view.

### DIFF
--- a/affiliates/users/urls.py
+++ b/affiliates/users/urls.py
@@ -1,4 +1,7 @@
 from django.conf.urls import patterns, url
+from django.views.decorators.cache import never_cache
+
+from django_browserid.views import CsrfToken
 
 from affiliates.users import views
 
@@ -6,4 +9,9 @@ from affiliates.users import views
 urlpatterns = patterns('',
     url(r'^profile/(?P<pk>\d+)/$', views.UserProfileView.as_view(), name='users.profile'),
     url(r'^login_required/$', views.login_required, name='users.login_required'),
+
+    # Temporary workaround for bug 1014273: Do not cache CSRFToken view.
+    # We override the django_browserid version by coming first in the
+    # URLConf.
+    url(r'^browserid/csrf/$', never_cache(CsrfToken.as_view())),
 )


### PR DESCRIPTION
The production site seems to be caching the index page and CSRF token
view used by django_browserid to fetch a token for POSTing the Persona
assertion. This causes failures when logging in as you POST with a 
cached token. Trying to login again works, however, because the failed
POST doesn’t get cached and you get assigned a proper token, which
updates your CSRF cookie. Since you now have a different cookie and all
requests vary by cookie while not logged in, the second time it will
fetch the correct token and POST it properly.

By marking the CSRF view as not cached, we force the request to set a 
CSRF cookie and to send the correct CSRF token, which means the POST
that follows it will go through correctly.
