### PR TITLE
Bug 1014273: Do not cache for anonymous users getting cookies.

### DIFF
--- a/affiliates/base/middleware.py
+++ b/affiliates/base/middleware.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.cache import add_never_cache_headers
 
 from commonware.response.middleware import FrameOptionsHeader as CommonwareFrameOptionsHeader
 
@@ -28,3 +29,15 @@ class FrameOptionsHeader(CommonwareFrameOptionsHeader):
             return response
         else:
             return super(FrameOptionsHeader, self).process_response(request, response)
+
+
+class AnonymousCookieNoCache(object):
+    """
+    If the user is anonymous, sent no cookies, and the response set some
+    cookies, do not cache.
+    """
+    def process_response(self, request, response):
+        if not request.COOKIES and request.user.is_anonymous() and response.cookies:
+            add_never_cache_headers(response)
+
+        return response

--- a/affiliates/settings/base.py
+++ b/affiliates/settings/base.py
@@ -38,6 +38,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'affiliates.facebook.middleware.FacebookAuthenticationMiddleware',
+    'affiliates.base.middleware.AnonymousCookieNoCache',
     'session_csrf.CsrfMiddleware',  # Must be after auth middleware.
     'django.contrib.messages.middleware.MessageMiddleware',
     'commonware.middleware.StrictTransportMiddleware',


### PR DESCRIPTION
Our load balancer is currently caching responses that send no cookies,
which causes a problem when that response sends a CSRF cookie. Since it
caches the response, all users get the same CSRF cookie, which causes
403 issues when the user attempts to POST during login.

The solution is to not cache responses under the specific circumstance
where a user is anonymous, sent no cookies, and received cookies. This
way, if a user comes in with cookies already set, we can still benefit
from caching for them without an issue since we vary on cookies. But 
users who need their cookies set with the CSRF token for the first time
can get an un-cached response.
