### PR TITLE
Fix bug 1018989: Alter base template to work without context processors.

### DIFF
--- a/affiliates/base/templates/base/base.html
+++ b/affiliates/base/templates/base/base.html
@@ -15,7 +15,9 @@
     <meta property="og:title" content="{% block og_title %}{{ _('Firefox Affiliates') }}{% endblock %}">
     <meta property="og:type" content="{% block og_type %}website{% endblock %}">
     <meta property="og:image" content="{% block og_image %}{{ absolutify(static('img/affiliates-shield-300.jpg')) }}{% endblock %}">
-    <meta property="og:url" content="{% block og_url %}{{ request.build_absolute_uri() }}{% endblock %}">
+    {% if request %}
+      <meta property="og:url" content="{% block og_url %}{{ request.build_absolute_uri() }}{% endblock %}">
+    {% endif %}
     <meta property="og:site_name" content="{{ _('Firefox Affiliates') }}">
     <meta property="og:description" content="{{ meta_description }}">
 
@@ -97,7 +99,7 @@
 
       {% block newsletter %}
         {# Email subscriptions are only shown for English locales. #}
-        {% if LANG.startswith('en') %}
+        {% if LANG and LANG.startswith('en') %}
           <section id="newsletter" class="section">
             <div class="contain">
 
@@ -211,7 +213,7 @@
     {% endblock %}
 
     <script src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
-    {% if settings.DEV %}
+    {% if settings and settings.DEV %}
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>
     {% endif %}
   </body>

--- a/affiliates/base/tests/test_views.py
+++ b/affiliates/base/tests/test_views.py
@@ -1,4 +1,5 @@
 from django.test.client import RequestFactory
+from django.views.defaults import server_error
 
 import basket
 from funfactory.urlresolvers import reverse
@@ -61,6 +62,14 @@ class ErrorPageTests(TestCase):
 
             self.in_facebook_app.assert_called_with(request)
             render.assert_called_with(request, 'facebook/error.html', status=500)
+
+    def test_500_renders(self):
+        """
+        Ensure that the built-in 500 view can render without errors.
+        """
+        request = self.factory.get('/')
+        server_error(request)  # No exceptions! Hopefully, at least.
+
 
 
 class HomeTests(TestCase):


### PR DESCRIPTION
Fixes some issues with the base template assuming certain variables 
exist.

Tested by visiting http://localhost:8000/500 and fixing errors until they stopped popping up.
