### PR TITLE
Added 100% Locales For Deprecation Message

### DIFF
--- a/affiliates/settings/base.py
+++ b/affiliates/settings/base.py
@@ -429,4 +429,4 @@ FACEBOOK_APP_URL = lazy(facebook_app_url_lazy, str)()
 GA_ACCOUNT_CODE = ''
 
 # List Of Locales Where Firefox Friends Messaging Is Translated & Enabled
-FRIENDS_MSG_LOCALES = ['en-US']
+FRIENDS_MSG_LOCALES = ['cs', 'de', 'en-US', 'fr', 'nl', 'pt-BR', 'sl', 'sr']


### PR DESCRIPTION
@Osmose 
I am enabling the 100% locales for the deprecation message.

Note that there are some locales that look to be 100% that are not enabled in PROD_LANGUAGES:

* NL
* pt-BR
* SR

Is this intentional?

https://l10n.mozilla-community.org/~flod/webstatus/?product=affiliates